### PR TITLE
feat: add option for overwriting indexes

### DIFF
--- a/harpoon
+++ b/harpoon
@@ -47,12 +47,40 @@ view() {
     _switch "$name" "$path"
 }
 
-add() {
-    extended="$1"
+_getBookmark() {
+    extended=$1
+
     base_info='#{session_name}=#{session_path}'
     pane_info=':#{window_index}.#{pane_index}'
-    tmux display -p "$base_info$([ "$extended" = 1 ] && echo "$pane_info")" >>"$cachefile"
+    bookmark=$(tmux display -p "$base_info$([ "$extended" = true ] && echo "$pane_info")")
+    echo "$bookmark"
+}
+
+_dedupe() {
     awk -i inplace '!seen[$0]++' "$cachefile" # de-duplicate
+}
+
+overwrite() {
+    bookmark=$(_getBookmark "$1")
+    index=$2
+
+    linenumbers=$(wc -l <"$cachefile")
+    if [ "$linenumbers" -gt "$index" ]; then
+        escaped_bookmark=$(echo "$bookmark" | sed 's/\//\\\//g')
+        sed -i "${index}s/.*/$escaped_bookmark/" "$cachefile"
+    else
+        echo "$bookmark" >>"$cachefile"
+    fi
+
+    _dedupe
+    exec tmux display "Tracking session #{session_name} in index $index"
+}
+
+add() {
+    bookmark=$(_getBookmark "$1")
+
+    echo "$bookmark" >>"$cachefile"
+    _dedupe
     exec tmux display 'Tracking session #{session_name}'
 }
 
@@ -90,11 +118,13 @@ list_sessions() { tmux ls -F '#{session_name}=#{session_path}'; }
 bold() { printf "\033[1m%s\033[0m\n" "$*"; }
 
 main() {
-    while getopts ":haAr:ls:e" opt; do
+    while getopts ":haAo:O:r:ls:e" opt; do
         case "$opt" in
         h | :) help && exit 0 ;;
-        a) add ;;
-        A) add 1 ;;
+        a) add false ;;
+        A) add true ;;
+        o) overwrite false "$OPTARG" ;;
+        O) overwrite true "$OPTARG" ;;
         r) remove "$OPTARG" ;;
         l) view ;;
         s) switch "$OPTARG" ;;

--- a/harpoon
+++ b/harpoon
@@ -54,8 +54,7 @@ _getBookmark() {
 
     base_info='#{session_name}=#{session_path}'
     pane_info=':#{window_index}.#{pane_index}'
-    bookmark=$(tmux display -p "$base_info$([ "$extended" = true ] && echo "$pane_info")")
-    echo "$bookmark"
+    echo tmux display -p "$base_info$([ "$extended" = true ] && echo "$pane_info")"
 }
 
 _dedupe() {

--- a/harpoon
+++ b/harpoon
@@ -19,7 +19,9 @@ help() {
     echo "Options:"
     echo "    -a                    Track current tmux session"
     echo "    -A                    Track pane within current tmux session"
-    echo "    -r [session_name]     Stop tracking session with session name. If"
+    echo "    -r [index]            Replace tracked entry at index with current session"
+    echo "    -R [index]            Replace tracked entry at index with current pane within session"
+    echo "    -d [session_name]     Stop tracking session with session name. If"
     echo "                          session_name is not passed then remove current session"
     echo "    -l                    List tracked sessions"
     echo "    -s [index]            Switch to the session at the specified index in the"
@@ -118,14 +120,14 @@ list_sessions() { tmux ls -F '#{session_name}=#{session_path}'; }
 bold() { printf "\033[1m%s\033[0m\n" "$*"; }
 
 main() {
-    while getopts ":haAo:O:r:ls:e" opt; do
+    while getopts ":haAr:R:d:ls:e" opt; do
         case "$opt" in
         h | :) help && exit 0 ;;
         a) add false ;;
         A) add true ;;
-        o) overwrite false "$OPTARG" ;;
-        O) overwrite true "$OPTARG" ;;
-        r) remove "$OPTARG" ;;
+        r) overwrite false "$OPTARG" ;;
+        R) overwrite true "$OPTARG" ;;
+        d) remove "$OPTARG" ;;
         l) view ;;
         s) switch "$OPTARG" ;;
         e) edit_file ;;

--- a/harpoon
+++ b/harpoon
@@ -54,7 +54,7 @@ _getBookmark() {
 
     base_info='#{session_name}=#{session_path}'
     pane_info=':#{window_index}.#{pane_index}'
-    echo tmux display -p "$base_info$([ "$extended" = true ] && echo "$pane_info")"
+    tmux display -p "$base_info$([ "$extended" = true ] && echo "$pane_info")"
 }
 
 _dedupe() {

--- a/harpoon
+++ b/harpoon
@@ -61,7 +61,7 @@ _dedupe() {
     awk -i inplace '!seen[$0]++' "$cachefile" # de-duplicate
 }
 
-overwrite() {
+replace() {
     bookmark=$(_getBookmark "$1")
     index=$2
 
@@ -124,8 +124,8 @@ main() {
         h | :) help && exit 0 ;;
         a) add false ;;
         A) add true ;;
-        r) overwrite false "$OPTARG" ;;
-        R) overwrite true "$OPTARG" ;;
+        r) replace false "$OPTARG" ;;
+        R) replace true "$OPTARG" ;;
         d) remove "$OPTARG" ;;
         l) view ;;
         s) switch "$OPTARG" ;;

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,8 @@ Usage:
 Options:
     -a                    Track current tmux session
     -A                    Track pane within current tmux session
+    -o [index]            Overwrite tracked index with current session in tmux session
+    -O [index]            Overwrite tracked index with current pane in tmux session
     -r [session_name]     Stop tracking session with session name. If
                           session_name is not passed then remove current session
     -l                    List tracked sessions
@@ -47,6 +49,24 @@ bind -n M-e run 'harpoon -s 2'
 bind -n M-o run 'harpoon -s 3'
 bind -n M-s run 'harpoon -s 4'
 ```
+
+To map panes or session to a specific index, use the -o/O flag:
+
+```conf
+bind -n M-q run 'harpoon -s 1'  # alt-q goes to index 1
+bind M-q run 'harpoon -O 1'     # prefix+alt+q adds pane to index 1
+
+bind -n M-w run 'harpoon -s 2'
+bind M-w run 'harpoon -O 2'
+
+... etc
+```
+
+The above config will essentially let you map panes to your keybindings, so that pressing
+your bind for a given index will take you to the marked pane, and pressing prefix + your bind 
+will mark the current pane to your keybind.
+
+If there is no pane/session in the given index, it will be appended to the list instead.
 
 ## Example
 

--- a/readme.md
+++ b/readme.md
@@ -44,18 +44,14 @@ bind -n M-b run 'harpoon -a'
 bind -n .   run 'harpoon -A'
 bind -n M-v run 'harpoon -l'
 bind -n M-i run 'harpoon -e'
-bind -n M-q run 'harpoon -s 1'
+bind -n M-q run 'harpoon -s 1'  # alt+q goes to index 1
+bind M-q run 'harpoon -r 1'     # prefix alt+q replace entry index 1 with current session
 bind -n M-w run 'harpoon -s 2'
+bind M-w run 'harpoon -R 2'     # replace entry at index 2 with current pane within session
 bind -n M-e run 'harpoon -s 3'
 bind -n M-r run 'harpoon -s 4'
 
-# Map panes or sessions to specific by replacing entires
-# If there is no pane/session in the given index, it will be appended to the list instead.
-bind -n M-q run 'harpoon -s 1'  # alt+q goes to index 1
-bind M-q run 'harpoon -r 1'     # prefix+alt+q adds pane to index 1
-
-bind -n M-w run 'harpoon -s 2'  
-bind M-w run 'harpoon -R 2'     # adds session instead of pane to index 2
+# Note: If there is no entry at the given index, it is appended to the list instead.# adds pane instead of session to index 2
 ```
 
 ## Example

--- a/readme.md
+++ b/readme.md
@@ -23,9 +23,9 @@ Usage:
 Options:
     -a                    Track current tmux session
     -A                    Track pane within current tmux session
-    -o [index]            Overwrite tracked index with current session in tmux session
-    -O [index]            Overwrite tracked index with current pane in tmux session
-    -r [session_name]     Stop tracking session with session name. If
+    -r [index]            Replace tracked entry at index with current session
+    -R [index]            Replace tracked entry at index with current pane within session
+    -d [session_name]     Stop tracking session with session name. If
                           session_name is not passed then remove current session
     -l                    List tracked sessions
     -s [index]            Switch to the session at the specified index in the
@@ -44,29 +44,19 @@ bind -n M-b run 'harpoon -a'
 bind -n .   run 'harpoon -A'
 bind -n M-v run 'harpoon -l'
 bind -n M-i run 'harpoon -e'
-bind -n M-n run 'harpoon -s 1'
-bind -n M-e run 'harpoon -s 2'
-bind -n M-o run 'harpoon -s 3'
-bind -n M-s run 'harpoon -s 4'
-```
-
-To map panes or session to a specific index, use the -o/O flag:
-
-```conf
-bind -n M-q run 'harpoon -s 1'  # alt-q goes to index 1
-bind M-q run 'harpoon -O 1'     # prefix+alt+q adds pane to index 1
-
+bind -n M-q run 'harpoon -s 1'
 bind -n M-w run 'harpoon -s 2'
-bind M-w run 'harpoon -O 2'
+bind -n M-e run 'harpoon -s 3'
+bind -n M-r run 'harpoon -s 4'
 
-... etc
+# Map panes or sessions to specific by replacing entires
+# If there is no pane/session in the given index, it will be appended to the list instead.
+bind -n M-q run 'harpoon -s 1'  # alt+q goes to index 1
+bind M-q run 'harpoon -r 1'     # prefix+alt+q adds pane to index 1
+
+bind -n M-w run 'harpoon -s 2'  
+bind M-w run 'harpoon -R 2'     # adds session instead of pane to index 2
 ```
-
-The above config will essentially let you map panes to your keybindings, so that pressing
-your bind for a given index will take you to the marked pane, and pressing prefix + your bind 
-will mark the current pane to your keybind.
-
-If there is no pane/session in the given index, it will be appended to the list instead.
 
 ## Example
 


### PR DESCRIPTION
also refactored add method to avoid code duplication

The idea is to be able to set a bookmark for a given keybind, so that i.e:

I use alt+q to go to index 1
I use alt+w to go to index 2

When I want to pin a pane/session to alt+q, I can press prefix+alt+q to store that pane on index 1, which alt+q is bound to. 
This avoids manually maintaining the index list when all you want is to put a bookmark for a given index