### PR TITLE
fix: "replace" flag appended instead of overwriting when replacing the last entry

### DIFF
--- a/harpoon
+++ b/harpoon
@@ -66,7 +66,7 @@ replace() {
     index=$2
 
     linenumbers=$(wc -l <"$cachefile")
-    if [ "$linenumbers" -gt "$index" ]; then
+    if [ "$linenumbers" -ge "$index" ]; then
         escaped_bookmark=$(echo "$bookmark" | sed 's/\//\\\//g')
         sed -i "${index}s/.*/$escaped_bookmark/" "$cachefile"
     else


### PR DESCRIPTION
If list was n items, indexing in the nth items appended instead of overwriting